### PR TITLE
feat circleページの新歓日程画面崩れ修正

### DIFF
--- a/main/components/organisms/ListItem/CircleNewJoyListItemSP.tsx
+++ b/main/components/organisms/ListItem/CircleNewJoyListItemSP.tsx
@@ -9,12 +9,13 @@ type Props = {
   circleNewJoy: CircleNewJoy
 }
 const CircleNewJoyListItemSP: FC<Props> = ({ slug, circleNewJoy }) => {
+  //日時、時間でwidth指定しているのは、時間が開始のみのときに画面崩れるのを防止するためです！！！！
   return (
     <div
       className="border border-4 border-gray-300 bg-white rounded-lg flex justify-between items-center px-6 py-2 mx-auto mb-2"
       style={{ width: 320 }}
     >
-      <div className="w-full pr-2">
+      <div className="w-full pr-3">
         <h3 className="text-black font-bold mb-1">{circleNewJoy.title}</h3>
         <p className="text-sm border-b border-gray-400 flex mb-1">
           <span className="text-gray-400 whitespace-nowrap text-xs pl-1">
@@ -25,12 +26,18 @@ const CircleNewJoyListItemSP: FC<Props> = ({ slug, circleNewJoy }) => {
           </span>
         </p>
         <div className="text-sm flex">
-          <div className="mr-2 border-b border-gray-400 whitespace-nowrap">
+          <div
+            className="mr-2 border-b border-gray-400 whitespace-nowrap"
+            style={{ width: 120 }}
+          >
             <span className="text-gray-400 text-xs pl-1">日時</span>
             <span className="px-2">{getDate(circleNewJoy.startDate)}</span>
           </div>
 
-          <span className="block w-full text-center border-b border-gray-400 whitespace-nowrap">
+          <span
+            className="block w-full text-center border-b border-gray-400 whitespace-nowrap"
+            style={{ width: 90 }}
+          >
             {getTime(circleNewJoy.startDate, circleNewJoy.endDate)}
           </span>
         </div>


### PR DESCRIPTION
## 対応済み

- circleページの新歓画面崩れ(終了時刻がない場合)
![image](https://user-images.githubusercontent.com/63891531/109386592-f5944400-793e-11eb-9beb-899d69bd0eb3.png)

- 文字数が変化したときの主催サークルの画面崩れ(→feat 新歓詳細で修正(コンポーネント切り出ししたため))
![image](https://user-images.githubusercontent.com/63891531/109387023-05f9ee00-7942-11eb-9720-b6ada555ab20.png)
![image](https://user-images.githubusercontent.com/63891531/109387011-f2e71e00-7941-11eb-82f2-98d734ce69a5.png)

## 未対応


## 対応不要
- 通常活動場所はローカルでは正しく出ていたので、反映待ちかと思われます。

![image](https://user-images.githubusercontent.com/63891531/109386634-486dfb80-793f-11eb-97ba-13d0cc521a1e.png)



