### PR TITLE
Fix 2/27デザイン修正案のwipで入れ逃した部分

### DIFF
--- a/main/components/organisms/Main/MainUucircleBottomButtons.tsx
+++ b/main/components/organisms/Main/MainUucircleBottomButtons.tsx
@@ -8,7 +8,20 @@ SwiperCore.use([Navigation, Pagination, Scrollbar, A11y])
 type Props = {}
 const MainUucircleBottomButtons: FC<Props> = () => {
   const { isMd } = useMediaQuery()
+  const params: Swiper = {
+    //Swiperの設定
 
+    initialSlide: 1,
+    spaceBetween: 50,
+    slidesPerView: 1,
+    centeredSlides: true,
+    // autoplay: {
+    //   delay: 4000,
+    //   disableOnInteraction: false,
+    // },
+    // loop: true,
+    navigation: true,
+  }
   return (
     <div className="bg-gray-100  pt-10 pb-10 ">
       <div className="text-center mb-4 mx-8">
@@ -70,12 +83,7 @@ const MainUucircleBottomButtons: FC<Props> = () => {
             </button>
           </nav>
         ) : (
-          <Swiper
-            spaceBetween={50}
-            slidesPerView={1}
-            initialSlide={1}
-            navigation
-          >
+          <Swiper {...params}>
             <nav
               className=""
               style={{ margin: '0 auto!important' }}

--- a/main/components/organisms/Main/MainUucircleTopButtons.tsx
+++ b/main/components/organisms/Main/MainUucircleTopButtons.tsx
@@ -9,7 +9,20 @@ SwiperCore.use([Navigation, Pagination, Scrollbar, A11y])
 type Props = {}
 const MainUucircleTopButtons: FC<Props> = () => {
   const { isMd } = useMediaQuery()
+  const params: Swiper = {
+    //Swiperの設定
 
+    initialSlide: 1,
+    spaceBetween: 50,
+    slidesPerView: 1,
+    centeredSlides: true,
+    // autoplay: {
+    //   delay: 4000,
+    //   disableOnInteraction: false,
+    // },
+    // loop: true,
+    navigation: true,
+  }
   return (
     <div className="flex justify-center pt-10 pb-10 bg-gray-100">
       {isMd ? (
@@ -93,7 +106,7 @@ const MainUucircleTopButtons: FC<Props> = () => {
           </button>
         </nav>
       ) : (
-        <Swiper spaceBetween={50} slidesPerView={1} initialSlide={1} navigation>
+        <Swiper {...params}>
           <nav className="mx-3" style={{ margin: 'auto!important' }}>
             <SwiperSlide className="text-center">
               <button

--- a/main/pages/circle/tag/[tag].tsx
+++ b/main/pages/circle/tag/[tag].tsx
@@ -1,73 +1,78 @@
-import { GetServerSideProps, NextPage } from "next";
-import { BaseFooter } from "@/components/layouts/BaseFooter";
-import { BaseLayout } from "@/components/layouts/BaseLayout";
-import { BaseCircleList } from "@/components/organisms/List/BaseCircleList";
-import { getCircleByTag } from "@/infra/api/circle";
-import { Circle } from "@/lib/types/model/Circle";
-import { TwoColumnContainer } from "@/components/molecules/Container/TwoColumnContainer";
-import { CircleSidebar } from "@/components/organisms/Circles/CircleSidebar";
-import { useRouter } from "next/dist/client/router";
-import { __ } from "@/lang/ja";
-import { categoryToCircleType } from "@/lib/utils/category/Category";
-import { Category } from "@/lib/enum/app/Category";
-import Head from "next/head";
-import { BaseHead } from "@/components/layouts/BaseHead";
+import { GetServerSideProps, NextPage } from 'next'
+import { BaseFooter } from '@/components/layouts/BaseFooter'
+import { BaseLayout } from '@/components/layouts/BaseLayout'
+import { BaseCircleList } from '@/components/organisms/List/BaseCircleList'
+import { getCircleByTag } from '@/infra/api/circle'
+import { Circle } from '@/lib/types/model/Circle'
+import { TwoColumnContainer } from '@/components/molecules/Container/TwoColumnContainer'
+import { CircleSidebar } from '@/components/organisms/Circles/CircleSidebar'
+import { useRouter } from 'next/dist/client/router'
+import { __ } from '@/lang/ja'
+import { categoryToCircleType } from '@/lib/utils/category/Category'
+import { Category } from '@/lib/enum/app/Category'
+import Head from 'next/head'
+import { BaseHead } from '@/components/layouts/BaseHead'
 
 type Props = {
-    errorCode?: number
-    circles?: Circle[]
+  errorCode?: number
+  circles?: Circle[]
 }
-const Page: NextPage<Props> = ({
-    circles
-}) => {
-    const router = useRouter()
-    const { tag } = router.query
+const Page: NextPage<Props> = ({ circles }) => {
+  const router = useRouter()
+  const { tag } = router.query
 
-    return (
-        <div>
-            <BaseHead
-                title={ `${__(String(tag).toUpperCase())}タグ検索` }
-            />
+  return (
+    <div>
+      <BaseHead title={`${__(String(tag).toUpperCase())}タグ検索`} />
 
-            <BaseLayout>
-                <div className="bg-gray-100 px-2">
-                    <TwoColumnContainer sidebar={<CircleSidebar />}>
-                        <h1 className="text-2xl py-8">{ __(String(tag).toUpperCase()) }</h1>
+      <BaseLayout>
+        <div className="bg-gray-100 px-2">
+          <TwoColumnContainer sidebar={<CircleSidebar />}>
+            <h1 className="text-2xl py-8">{__(String(tag).toUpperCase())}</h1>
 
-                        {__(String(tag).toUpperCase(), "CircleTagTitle") ? (
-                            <p className="text-base pb-4">{ __(String(tag).toUpperCase(), "CircleTagTitle") }</p>
-                        ) : ''}
-                        {__(String(tag).toUpperCase(), "CircleTagText") ? (
-                            <p className="text-sm pb-8">{ __(String(tag).toUpperCase(), "CircleTagText") }</p>
-                        ) : ''}
+            {__(String(tag).toUpperCase(), 'CircleTagTitle') ? (
+              <p className="text-base pb-4 font-bold">
+                {__(String(tag).toUpperCase(), 'CircleTagTitle')}
+              </p>
+            ) : (
+              ''
+            )}
+            {__(String(tag).toUpperCase(), 'CircleTagText') ? (
+              <p className="text-sm pb-8">
+                {__(String(tag).toUpperCase(), 'CircleTagText')}
+              </p>
+            ) : (
+              ''
+            )}
 
-                        {/*  サークル一覧 */}
-                        <BaseCircleList circles={circles} />
-                    </TwoColumnContainer>
-                </div>
-
-                {/*  フッター */}
-                <BaseFooter />
-            </BaseLayout>
+            {/*  サークル一覧 */}
+            <BaseCircleList circles={circles} />
+          </TwoColumnContainer>
         </div>
-    )
+
+        {/*  フッター */}
+        <BaseFooter />
+      </BaseLayout>
+    </div>
+  )
 }
 
-export const getServerSideProps: GetServerSideProps<Props> = async ({ params, res }) => {
-    if (!params.tag || Array.isArray(params.tag)) {
-        res.statusCode = 404;
-        return { props: { errorCode: 404 } }
-    }
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  params,
+  res,
+}) => {
+  if (!params.tag || Array.isArray(params.tag)) {
+    res.statusCode = 404
+    return { props: { errorCode: 404 } }
+  }
 
-    const {
-        circles 
-    } = await getCircleByTag(params.tag)
+  const { circles } = await getCircleByTag(params.tag)
 
-    return {
-        props: {
-            circles
-        }
-    }
+  return {
+    props: {
+      circles,
+    },
+  }
 }
 
 export default Page

--- a/main/pages/index.tsx
+++ b/main/pages/index.tsx
@@ -36,12 +36,12 @@ const Index: NextPage<Props> = ({ advertises, circles }) => {
   return (
     <div>
       <Head>
-          <title>UU-circles</title>
-          <meta property="og:title" content={`UU-circles`} />
-          <meta property="og:site_name" content="UU-circles" />
-          <meta property="og:type" content={'website'} />
-          <meta property="og:url" content={`https://uu-circles.com/`} />
-          <meta name="twitter:site" content="@Ulab_uu" />
+        <title>UU-circles</title>
+        <meta property="og:title" content={`UU-circles`} />
+        <meta property="og:site_name" content="UU-circles" />
+        <meta property="og:type" content={'website'} />
+        <meta property="og:url" content={`https://uu-circles.com/`} />
+        <meta name="twitter:site" content="@Ulab_uu" />
       </Head>
 
       <BaseLayout>
@@ -65,7 +65,7 @@ const Index: NextPage<Props> = ({ advertises, circles }) => {
           </div>
         </BaseContainer>
 
-        <div>
+        <div className="bg-gray-100">
           {/*  フッター */}
 
           <MainUucircleAd />

--- a/main/styles/index.css
+++ b/main/styles/index.css
@@ -34,10 +34,14 @@ body {
   content: '#';
 }
 
-/* swiper右左デザイン */
+/* swiper右左デザイン 上書き*/
 .swiper-button-next::after {
+  transform: scale(0.7, 0.7) !important;
   color: #c4c4c4 !important;
+  margin-right: 5px;
 }
 .swiper-button-prev::after {
+  transform: scale(0.7, 0.7) !important;
   color: #c4c4c4 !important;
+  margin-left: 5px;
 }


### PR DESCRIPTION
## tag/slugのページの太字を適応しました
![image](https://user-images.githubusercontent.com/63891531/109423219-fbaf2100-7a21-11eb-8e90-526855538d51.png)

## 左右ボタンのサイズを70%に抑えました←これはコンフリクト出たら消して大丈夫です
![image](https://user-images.githubusercontent.com/63891531/109423238-09fd3d00-7a22-11eb-874b-15b9433485db.png)
