### PR TITLE
fix SPの新歓全体でのリンクとカーソル(SPデザインがサークルページで使われているため)

### DIFF
--- a/main/components/organisms/ListItem/CircleNewJoyListItemSP.tsx
+++ b/main/components/organisms/ListItem/CircleNewJoyListItemSP.tsx
@@ -11,51 +11,51 @@ type Props = {
 const CircleNewJoyListItemSP: FC<Props> = ({ slug, circleNewJoy }) => {
   //日時、時間でwidth指定しているのは、時間が開始のみのときに画面崩れるのを防止するためです！！！！
   return (
-    <div
-      className="border border-gray-300 bg-white rounded-lg flex justify-between items-center px-6 py-2 mx-auto mb-2"
-      style={{ width: 320 }}
+    <Link
+      href="/circle/[slug]/newjoy/[circleNewJoy]"
+      as={`/circle/${slug}/newjoy/${circleNewJoy.id}`}
     >
-      <div className="w-full pr-3">
-        <h3 className="text-black font-bold mb-1">{circleNewJoy.title}</h3>
-        <p className="text-sm border-b border-gray-400 flex mb-1">
-          <span className="text-gray-400 whitespace-nowrap text-xs pl-1">
-            場所
-          </span>
-          <span className="block w-full text-center">
-            {__(circleNewJoy.placeOfActivity)}
-          </span>
-        </p>
-        <div className="text-sm flex">
-          <div
-            className="mr-2 border-b border-gray-400 whitespace-nowrap"
-            style={{ width: 120 }}
-          >
-            <span className="text-gray-400 text-xs pl-1">日時</span>
-            <span className="px-2">{getDate(circleNewJoy.startDate)}</span>
-          </div>
+      <div
+        className="border border-gray-300 bg-white rounded-lg flex justify-between items-center px-6 py-2 mx-auto mb-2"
+        style={{ width: 320 }}
+      >
+        <div className="w-full pr-3">
+          <h3 className="text-black font-bold mb-1">{circleNewJoy.title}</h3>
+          <p className="text-sm border-b border-gray-400 flex mb-1">
+            <span className="text-gray-400 whitespace-nowrap text-xs pl-1">
+              場所
+            </span>
+            <span className="block w-full text-center">
+              {__(circleNewJoy.placeOfActivity)}
+            </span>
+          </p>
+          <div className="text-sm flex">
+            <div
+              className="mr-2 border-b border-gray-400 whitespace-nowrap"
+              style={{ width: 120 }}
+            >
+              <span className="text-gray-400 text-xs pl-1">日時</span>
+              <span className="px-2">{getDate(circleNewJoy.startDate)}</span>
+            </div>
 
-          <span
-            className="block w-full text-center border-b border-gray-400 whitespace-nowrap"
-            style={{ width: 90 }}
-          >
-            {getTime(circleNewJoy.startDate, circleNewJoy.endDate)}
-          </span>
+            <span
+              className="block w-full text-center border-b border-gray-400 whitespace-nowrap"
+              style={{ width: 90 }}
+            >
+              {getTime(circleNewJoy.startDate, circleNewJoy.endDate)}
+            </span>
+          </div>
         </div>
-      </div>
-      <div className="mr-4">
-        <Link
-          href="/circle/[slug]/newjoy/[circleNewJoy]"
-          as={`/circle/${slug}/newjoy/${circleNewJoy.id}`}
-        >
+        <div className="mr-4">
           <div
-            className="text-white bg-blue-800 rounded-full text-xs flex items-center justify-center"
+            className="text-white bg-blue-800 rounded-full text-xs flex items-center justify-center cursor-pointer"
             style={{ width: 52, height: 52 }}
           >
             詳細
           </div>
-        </Link>
+        </div>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/main/components/organisms/ListItem/CircleNewJoyListItemSP.tsx
+++ b/main/components/organisms/ListItem/CircleNewJoyListItemSP.tsx
@@ -15,46 +15,48 @@ const CircleNewJoyListItemSP: FC<Props> = ({ slug, circleNewJoy }) => {
       href="/circle/[slug]/newjoy/[circleNewJoy]"
       as={`/circle/${slug}/newjoy/${circleNewJoy.id}`}
     >
-      <div
-        className="border border-gray-300 bg-white rounded-lg flex justify-between items-center px-6 py-2 mx-auto mb-2"
-        style={{ width: 320 }}
-      >
-        <div className="w-full pr-3">
-          <h3 className="text-black font-bold mb-1">{circleNewJoy.title}</h3>
-          <p className="text-sm border-b border-gray-400 flex mb-1">
-            <span className="text-gray-400 whitespace-nowrap text-xs pl-1">
-              場所
-            </span>
-            <span className="block w-full text-center">
-              {__(circleNewJoy.placeOfActivity)}
-            </span>
-          </p>
-          <div className="text-sm flex">
-            <div
-              className="mr-2 border-b border-gray-400 whitespace-nowrap"
-              style={{ width: 120 }}
-            >
-              <span className="text-gray-400 text-xs pl-1">日時</span>
-              <span className="px-2">{getDate(circleNewJoy.startDate)}</span>
-            </div>
+      <a>
+        <div
+          className="border border-gray-300 bg-white rounded-lg flex justify-between items-center px-6 py-2 mx-auto mb-2"
+          style={{ width: 320 }}
+        >
+          <div className="w-full pr-3">
+            <h3 className="text-black font-bold mb-1">{circleNewJoy.title}</h3>
+            <p className="text-sm border-b border-gray-400 flex mb-1">
+              <span className="text-gray-400 whitespace-nowrap text-xs pl-1">
+                場所
+              </span>
+              <span className="block w-full text-center">
+                {__(circleNewJoy.placeOfActivity)}
+              </span>
+            </p>
+            <div className="text-sm flex">
+              <div
+                className="mr-2 border-b border-gray-400 whitespace-nowrap"
+                style={{ width: 120 }}
+              >
+                <span className="text-gray-400 text-xs pl-1">日時</span>
+                <span className="px-2">{getDate(circleNewJoy.startDate)}</span>
+              </div>
 
-            <span
-              className="block w-full text-center border-b border-gray-400 whitespace-nowrap"
-              style={{ width: 90 }}
+              <span
+                className="block w-full text-center border-b border-gray-400 whitespace-nowrap"
+                style={{ width: 90 }}
+              >
+                {getTime(circleNewJoy.startDate, circleNewJoy.endDate)}
+              </span>
+            </div>
+          </div>
+          <div className="mr-4">
+            <div
+              className="text-white bg-blue-800 rounded-full text-xs flex items-center justify-center cursor-pointer"
+              style={{ width: 52, height: 52 }}
             >
-              {getTime(circleNewJoy.startDate, circleNewJoy.endDate)}
-            </span>
+              詳細
+            </div>
           </div>
         </div>
-        <div className="mr-4">
-          <div
-            className="text-white bg-blue-800 rounded-full text-xs flex items-center justify-center cursor-pointer"
-            style={{ width: 52, height: 52 }}
-          >
-            詳細
-          </div>
-        </div>
-      </div>
+      </a>
     </Link>
   )
 }


### PR DESCRIPTION
「開催済みの新歓はありません」のロジックは本番環境に既に適応済みでしたので実装不要でした。

また、 cursor-pointerはいらない予定でしたが、SPデザインをサークルページで使っていたため、「詳細」のcursor-pointerはつけておきました。
![image](https://user-images.githubusercontent.com/63891531/110208813-a913b000-7ecc-11eb-884c-11428763e1ec.png)

